### PR TITLE
fix(react): add missing dependency autoprefixer

### DIFF
--- a/templates/react/package.json
+++ b/templates/react/package.json
@@ -23,6 +23,7 @@
     "@testing-library/user-event": "14.1.0",
     "@vitejs/plugin-react": "^1.0.7",
     "jsdom": "^19.0.0",
+    "autoprefixer": "^10.4.4",
     "prettier-plugin-tailwindcss": "^0.1.8",
     "tailwindcss": "^3.0.23",
     "vite": "^2.9.0",


### PR DESCRIPTION
Autoprefixer was missing in the react template, crashing the app on initial setup and development script